### PR TITLE
Add state transition context

### DIFF
--- a/examples/sketch.rs
+++ b/examples/sketch.rs
@@ -1,10 +1,11 @@
 use ethereum_consensus::altair::light_client::Snapshot;
-use ethereum_consensus::phase0::mainnet::{apply_block, BeaconState, SignedBeaconBlock};
+use ethereum_consensus::phase0::mainnet::{self, apply_block, BeaconState, SignedBeaconBlock};
 
 fn main() {
+    let context = mainnet::context();
     let state = BeaconState::default();
     let signed_block = SignedBeaconBlock::default();
-    let post = apply_block(state, signed_block);
+    let post = apply_block(state, signed_block, &context);
     dbg!(post);
 
     let snapshot = Snapshot::default();

--- a/src/phase0/presets/mainnet.rs
+++ b/src/phase0/presets/mainnet.rs
@@ -9,6 +9,7 @@ pub use crate::phase0::operations::{
     AttestationData, Checkpoint, Deposit, DepositData, DepositMessage, Eth1Data, ProposerSlashing,
     SignedVoluntaryExit, VoluntaryExit,
 };
+use crate::phase0::presets::Preset;
 pub use crate::phase0::state_transition::apply_block;
 pub use crate::phase0::validator::Validator;
 use crate::primitives::{Epoch, Gwei, Slot};
@@ -45,6 +46,41 @@ pub const MAX_ATTESTER_SLASHINGS: usize = 2;
 pub const MAX_ATTESTATIONS: usize = 128;
 pub const MAX_DEPOSITS: usize = 16;
 pub const MAX_VOLUNTARY_EXITS: usize = 16;
+
+pub const PRESET: Preset = Preset {
+    max_committees_per_slot: MAX_COMMITTEES_PER_SLOT,
+    target_committee_size: TARGET_COMMITTEE_SIZE,
+    max_validators_per_committee: MAX_VALIDATORS_PER_COMMITTEE,
+    shuffle_round_count: SHUFFLE_ROUND_COUNT,
+    hysteresis_quotient: HYSTERESIS_QUOTIENT,
+    hysteresis_downward_multiplier: HYSTERESIS_DOWNWARD_MULTIPLIER,
+    hysteresis_upward_multiplier: HYSTERESIS_UPWARD_MULTIPLIER,
+    min_deposit_amount: MIN_DEPOSIT_AMOUNT,
+    max_effective_balance: MAX_EFFECTIVE_BALANCE,
+    effective_balance_increment: EFFECTIVE_BALANCE_INCREMENT,
+    min_attestation_inclusion_delay: MIN_ATTESTATION_INCLUSION_DELAY,
+    slots_per_epoch: SLOTS_PER_EPOCH,
+    min_seed_lookahead: MIN_SEED_LOOKAHEAD,
+    max_seed_lookahead: MAX_SEED_LOOKAHEAD,
+    min_epochs_to_inactivity_penalty: MIN_EPOCHS_TO_INACTIVITY_PENALTY,
+    epochs_per_eth1_voting_period: EPOCHS_PER_ETH1_VOTING_PERIOD,
+    slots_per_historical_root: SLOTS_PER_HISTORICAL_ROOT,
+    epochs_per_historical_vector: EPOCHS_PER_HISTORICAL_VECTOR,
+    epochs_per_slashings_vector: EPOCHS_PER_SLASHINGS_VECTOR,
+    historical_roots_limit: HISTORICAL_ROOTS_LIMIT,
+    validator_registry_limit: VALIDATOR_REGISTRY_LIMIT,
+    base_reward_factor: BASE_REWARD_FACTOR,
+    whistleblower_reward_quotient: WHISTLEBLOWER_REWARD_QUOTIENT,
+    proposer_reward_quotient: PROPOSER_REWARD_QUOTIENT,
+    inactivity_penalty_quotient: INACTIVITY_PENALTY_QUOTIENT,
+    min_slashing_penalty_quotient: MIN_SLASHING_PENALTY_QUOTIENT,
+    proportional_slashing_multiplier: PROPORTIONAL_SLASHING_MULTIPLIER,
+    max_proposer_slashings: MAX_PROPOSER_SLASHINGS,
+    max_attester_slashings: MAX_ATTESTER_SLASHINGS,
+    max_attestations: MAX_ATTESTATIONS,
+    max_deposits: MAX_DEPOSITS,
+    max_voluntary_exits: MAX_VOLUNTARY_EXITS,
+};
 
 pub type IndexedAttestation = operations::IndexedAttestation<MAX_VALIDATORS_PER_COMMITTEE>;
 pub type PendingAttestation = operations::PendingAttestation<MAX_VALIDATORS_PER_COMMITTEE>;

--- a/src/phase0/presets/mainnet.rs
+++ b/src/phase0/presets/mainnet.rs
@@ -11,6 +11,7 @@ pub use crate::phase0::operations::{
 };
 use crate::phase0::presets::Preset;
 pub use crate::phase0::state_transition::apply_block;
+use crate::phase0::state_transition::Context;
 pub use crate::phase0::validator::Validator;
 use crate::primitives::{Epoch, Gwei, Slot};
 
@@ -81,6 +82,10 @@ pub const PRESET: Preset = Preset {
     max_deposits: MAX_DEPOSITS,
     max_voluntary_exits: MAX_VOLUNTARY_EXITS,
 };
+
+pub fn context() -> Context {
+    Context::with_preset(&PRESET)
+}
 
 pub type IndexedAttestation = operations::IndexedAttestation<MAX_VALIDATORS_PER_COMMITTEE>;
 pub type PendingAttestation = operations::PendingAttestation<MAX_VALIDATORS_PER_COMMITTEE>;

--- a/src/phase0/presets/mainnet.rs
+++ b/src/phase0/presets/mainnet.rs
@@ -10,8 +10,15 @@ pub use crate::phase0::operations::{
     SignedVoluntaryExit, VoluntaryExit,
 };
 use crate::phase0::presets::Preset;
-pub use crate::phase0::state_transition::apply_block;
 use crate::phase0::state_transition::Context;
+pub use crate::phase0::state_transition::{
+    apply_block, compute_activation_exit_epoch, compute_committee, compute_domain,
+    compute_epoch_at_slot, compute_fork_data_root, compute_fork_digest, compute_proposer_index,
+    compute_shuffled_index, compute_signing_root, compute_start_slot_at_epoch, get_current_epoch,
+    get_domain, is_active_validator, is_eligible_for_activation, is_eligible_for_activation_queue,
+    is_slashable_attestation_data, is_slashable_validator, is_valid_indexed_attestation,
+    verify_block_signature, Error,
+};
 pub use crate::phase0::validator::Validator;
 use crate::primitives::{Epoch, Gwei, Slot};
 

--- a/src/phase0/presets/minimal.rs
+++ b/src/phase0/presets/minimal.rs
@@ -1,15 +1,3 @@
-pub use crate::domains::{DomainType, SigningData};
-use crate::phase0::beacon_block;
-pub use crate::phase0::beacon_block::{BeaconBlockHeader, SignedBeaconBlockHeader};
-use crate::phase0::beacon_state;
-use crate::phase0::beacon_state::{get_eth1_data_votes_bound, get_pending_attestations_bound};
-pub use crate::phase0::fork::{Fork, ForkData};
-use crate::phase0::operations;
-pub use crate::phase0::operations::{
-    AttestationData, Checkpoint, Deposit, DepositData, DepositMessage, Eth1Data, ProposerSlashing,
-    SignedVoluntaryExit, VoluntaryExit,
-};
-pub use crate::phase0::validator::Validator;
 use crate::primitives::{Epoch, Gwei, Slot};
 
 pub const MAX_COMMITTEES_PER_SLOT: u64 = 4;
@@ -45,51 +33,4 @@ pub const MAX_ATTESTATIONS: usize = 128;
 pub const MAX_DEPOSITS: usize = 16;
 pub const MAX_VOLUNTARY_EXITS: usize = 16;
 
-pub type IndexedAttestation = operations::IndexedAttestation<MAX_VALIDATORS_PER_COMMITTEE>;
-pub type PendingAttestation = operations::PendingAttestation<MAX_VALIDATORS_PER_COMMITTEE>;
-pub type HistoricalBatch = beacon_state::HistoricalBatch<SLOTS_PER_HISTORICAL_ROOT>;
-pub type AttesterSlashing = operations::AttesterSlashing<MAX_VALIDATORS_PER_COMMITTEE>;
-pub type Attestation = operations::Attestation<MAX_VALIDATORS_PER_COMMITTEE>;
-
-const ETH1_DATA_VOTES_BOUND: usize =
-    get_eth1_data_votes_bound(EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH as usize);
-const PENDING_ATTESTATIONS_BOUND: usize =
-    get_pending_attestations_bound(MAX_ATTESTATIONS, SLOTS_PER_EPOCH as usize);
-
-pub type BeaconState = beacon_state::BeaconState<
-    SLOTS_PER_HISTORICAL_ROOT,
-    HISTORICAL_ROOTS_LIMIT,
-    ETH1_DATA_VOTES_BOUND,
-    VALIDATOR_REGISTRY_LIMIT,
-    EPOCHS_PER_HISTORICAL_VECTOR,
-    EPOCHS_PER_SLASHINGS_VECTOR,
-    MAX_VALIDATORS_PER_COMMITTEE,
-    PENDING_ATTESTATIONS_BOUND,
->;
-
-pub type BeaconBlockBody = beacon_block::BeaconBlockBody<
-    MAX_PROPOSER_SLASHINGS,
-    MAX_VALIDATORS_PER_COMMITTEE,
-    MAX_ATTESTER_SLASHINGS,
-    MAX_ATTESTATIONS,
-    MAX_DEPOSITS,
-    MAX_VOLUNTARY_EXITS,
->;
-
-pub type BeaconBlock = beacon_block::BeaconBlock<
-    MAX_PROPOSER_SLASHINGS,
-    MAX_VALIDATORS_PER_COMMITTEE,
-    MAX_ATTESTER_SLASHINGS,
-    MAX_ATTESTATIONS,
-    MAX_DEPOSITS,
-    MAX_VOLUNTARY_EXITS,
->;
-
-pub type SignedBeaconBlock = beacon_block::SignedBeaconBlock<
-    MAX_PROPOSER_SLASHINGS,
-    MAX_VALIDATORS_PER_COMMITTEE,
-    MAX_ATTESTER_SLASHINGS,
-    MAX_ATTESTATIONS,
-    MAX_DEPOSITS,
-    MAX_VOLUNTARY_EXITS,
->;
+// TODO: specialize once `mainnet` has stabilized

--- a/src/phase0/presets/mod.rs
+++ b/src/phase0/presets/mod.rs
@@ -1,2 +1,39 @@
 pub mod mainnet;
 pub mod minimal;
+
+use crate::primitives::{Epoch, Gwei, Slot};
+
+pub struct Preset {
+    pub max_committees_per_slot: u64,
+    pub target_committee_size: u64,
+    pub max_validators_per_committee: usize,
+    pub shuffle_round_count: u64,
+    pub hysteresis_quotient: u64,
+    pub hysteresis_downward_multiplier: u64,
+    pub hysteresis_upward_multiplier: u64,
+    pub min_deposit_amount: Gwei,
+    pub max_effective_balance: Gwei,
+    pub effective_balance_increment: Gwei,
+    pub min_attestation_inclusion_delay: Slot,
+    pub slots_per_epoch: Slot,
+    pub min_seed_lookahead: Epoch,
+    pub max_seed_lookahead: Epoch,
+    pub min_epochs_to_inactivity_penalty: Epoch,
+    pub epochs_per_eth1_voting_period: usize,
+    pub slots_per_historical_root: usize,
+    pub epochs_per_historical_vector: usize,
+    pub epochs_per_slashings_vector: usize,
+    pub historical_roots_limit: usize,
+    pub validator_registry_limit: usize,
+    pub base_reward_factor: u64,
+    pub whistleblower_reward_quotient: u64,
+    pub proposer_reward_quotient: u64,
+    pub inactivity_penalty_quotient: u64,
+    pub min_slashing_penalty_quotient: u64,
+    pub proportional_slashing_multiplier: u64,
+    pub max_proposer_slashings: usize,
+    pub max_attester_slashings: usize,
+    pub max_attestations: usize,
+    pub max_deposits: usize,
+    pub max_voluntary_exits: usize,
+}

--- a/src/phase0/state_transition/context.rs
+++ b/src/phase0/state_transition/context.rs
@@ -1,0 +1,84 @@
+use crate::phase0::presets::Preset;
+use crate::primitives::{Epoch, Gwei, Slot};
+use ssz_rs::prelude::MerkleizationContext;
+
+#[derive(Debug, Default)]
+pub struct Context {
+    merkleization_context: MerkleizationContext,
+    pub max_committees_per_slot: u64,
+    pub target_committee_size: u64,
+    pub max_validators_per_committee: usize,
+    pub shuffle_round_count: u64,
+    pub hysteresis_quotient: u64,
+    pub hysteresis_downward_multiplier: u64,
+    pub hysteresis_upward_multiplier: u64,
+    pub min_deposit_amount: Gwei,
+    pub max_effective_balance: Gwei,
+    pub effective_balance_increment: Gwei,
+    pub min_attestation_inclusion_delay: Slot,
+    pub slots_per_epoch: Slot,
+    pub min_seed_lookahead: Epoch,
+    pub max_seed_lookahead: Epoch,
+    pub min_epochs_to_inactivity_penalty: Epoch,
+    pub epochs_per_eth1_voting_period: usize,
+    pub slots_per_historical_root: usize,
+    pub epochs_per_historical_vector: usize,
+    pub epochs_per_slashings_vector: usize,
+    pub historical_roots_limit: usize,
+    pub validator_registry_limit: usize,
+    pub base_reward_factor: u64,
+    pub whistleblower_reward_quotient: u64,
+    pub proposer_reward_quotient: u64,
+    pub inactivity_penalty_quotient: u64,
+    pub min_slashing_penalty_quotient: u64,
+    pub proportional_slashing_multiplier: u64,
+    pub max_proposer_slashings: usize,
+    pub max_attester_slashings: usize,
+    pub max_attestations: usize,
+    pub max_deposits: usize,
+    pub max_voluntary_exits: usize,
+}
+
+impl Context {
+    pub fn with_preset(preset: &Preset) -> Self {
+        Context {
+            max_committees_per_slot: preset.max_committees_per_slot,
+            target_committee_size: preset.target_committee_size,
+            max_validators_per_committee: preset.max_validators_per_committee,
+            shuffle_round_count: preset.shuffle_round_count,
+            hysteresis_quotient: preset.hysteresis_quotient,
+            hysteresis_downward_multiplier: preset.hysteresis_downward_multiplier,
+            hysteresis_upward_multiplier: preset.hysteresis_upward_multiplier,
+            min_deposit_amount: preset.min_deposit_amount,
+            max_effective_balance: preset.max_effective_balance,
+            effective_balance_increment: preset.effective_balance_increment,
+            min_attestation_inclusion_delay: preset.min_attestation_inclusion_delay,
+            slots_per_epoch: preset.slots_per_epoch,
+            min_seed_lookahead: preset.min_seed_lookahead,
+            max_seed_lookahead: preset.max_seed_lookahead,
+            min_epochs_to_inactivity_penalty: preset.min_epochs_to_inactivity_penalty,
+            epochs_per_eth1_voting_period: preset.epochs_per_eth1_voting_period,
+            slots_per_historical_root: preset.slots_per_historical_root,
+            epochs_per_historical_vector: preset.epochs_per_historical_vector,
+            epochs_per_slashings_vector: preset.epochs_per_slashings_vector,
+            historical_roots_limit: preset.historical_roots_limit,
+            validator_registry_limit: preset.validator_registry_limit,
+            base_reward_factor: preset.base_reward_factor,
+            whistleblower_reward_quotient: preset.whistleblower_reward_quotient,
+            proposer_reward_quotient: preset.proposer_reward_quotient,
+            inactivity_penalty_quotient: preset.inactivity_penalty_quotient,
+            min_slashing_penalty_quotient: preset.min_slashing_penalty_quotient,
+            proportional_slashing_multiplier: preset.proportional_slashing_multiplier,
+            max_proposer_slashings: preset.max_proposer_slashings,
+            max_attester_slashings: preset.max_attester_slashings,
+            max_attestations: preset.max_attestations,
+            max_deposits: preset.max_deposits,
+            max_voluntary_exits: preset.max_voluntary_exits,
+            ..Default::default()
+        }
+    }
+
+    pub fn for_merkleization(&self) -> &MerkleizationContext {
+        &self.merkleization_context
+    }
+}


### PR DESCRIPTION
We will need some sort of `Context` for a variety of state transition optimization we will want, and this also is a nice place to pass around some configuration data that is a bit unwieldy to pass around in other ways (e.g. thru compile-time constants)