### PR TITLE
define `PartialEq` for `Bytes32` and `Root` types

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -58,3 +58,9 @@ impl AsRef<[u8]> for Bytes32 {
         &self.0
     }
 }
+
+impl PartialEq<Root> for Bytes32 {
+    fn eq(&self, other: &Root) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}


### PR DESCRIPTION
there are several places in the state transition (e.g. see #26) where we compare `Bytes32` to a `Root` type.

to improve the ergonomics of state transition, we define a `PartialEq` instance here

