### PR TITLE
integrate recent ssz changes

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -10,11 +10,11 @@ const BLS_PUBLIC_KEY_BYTES_LEN: usize = 48;
 const BLS_SECRET_KEY_BYTES_LEN: usize = 32;
 
 pub fn hash<D: AsRef<[u8]>>(data: D) -> Bytes32 {
-    let mut result = Bytes32::default();
+    let mut result = vec![0u8; 32];
     let mut hasher = Sha256::new();
     hasher.update(data);
-    hasher.finalize_into(result.0.as_mut_slice().into());
-    result
+    hasher.finalize_into(result.as_mut_slice().into());
+    Bytes32(result.try_into().expect("correct input"))
 }
 
 #[derive(Debug, Error)]
@@ -177,11 +177,11 @@ impl Deserialize for PublicKey {
 }
 
 impl Merkleized for PublicKey {
-    fn hash_tree_root(&self, context: &MerkleizationContext) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
         let mut buffer = vec![];
         self.serialize(&mut buffer)?;
         pack_bytes(&mut buffer);
-        merkleize(&buffer, None, context)
+        merkleize(&buffer, None)
     }
 }
 
@@ -271,11 +271,11 @@ impl Deserialize for Signature {
 }
 
 impl Merkleized for Signature {
-    fn hash_tree_root(&self, context: &MerkleizationContext) -> Result<Node, MerkleizationError> {
+    fn hash_tree_root(&mut self) -> Result<Node, MerkleizationError> {
         let mut buffer = vec![];
         self.serialize(&mut buffer)?;
         pack_bytes(&mut buffer);
-        merkleize(&buffer, None, context)
+        merkleize(&buffer, None)
     }
 }
 

--- a/src/phase0/state_transition/context.rs
+++ b/src/phase0/state_transition/context.rs
@@ -1,11 +1,9 @@
 use crate::phase0::configs::{mainnet::CONFIG as MAINNET_CONFIG, Config};
 use crate::phase0::presets::{mainnet::PRESET as MAINNET_PRESET, Preset};
 use crate::primitives::{Epoch, Gwei, Slot, Version};
-use ssz_rs::prelude::MerkleizationContext;
 
 #[derive(Debug, Default)]
 pub struct Context {
-    merkleization_context: MerkleizationContext,
     pub max_committees_per_slot: u64,
     pub target_committee_size: u64,
     pub max_validators_per_committee: usize,
@@ -99,7 +97,6 @@ impl Context {
             ejection_balance: config.ejection_balance,
             churn_limit_quotient: config.churn_limit_quotient,
             min_per_epoch_churn_limit: config.min_per_epoch_churn_limit,
-            ..Default::default()
         }
     }
 
@@ -109,9 +106,5 @@ impl Context {
 
     pub fn for_minimal() -> Self {
         unimplemented!()
-    }
-
-    pub fn for_merkleization(&self) -> &MerkleizationContext {
-        &self.merkleization_context
     }
 }


### PR DESCRIPTION
main thing is to drop the `MerkleizationContext` which is now just static data at the global scope.

this PR also integrates some minor API changes for the List and Vector types that lay the ground-work for a broader effort in the `ssz_rs` repo to add hashing caching (and multiproofs eventually).