### PR TITLE
fix mutability on `BeaconBlock` type in `block_processing`

### DIFF
--- a/src/phase0/state_transition/block_processing.rs
+++ b/src/phase0/state_transition/block_processing.rs
@@ -160,7 +160,7 @@ fn process_block_header<
         MAX_VALIDATORS_PER_COMMITTEE,
         PENDING_ATTESTATIONS_BOUND,
     >,
-    _block: &mut BeaconBlock<
+    _block: &BeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,
@@ -341,7 +341,7 @@ pub fn process_block<
         MAX_VALIDATORS_PER_COMMITTEE,
         PENDING_ATTESTATIONS_BOUND,
     >,
-    block: &mut BeaconBlock<
+    block: &BeaconBlock<
         MAX_PROPOSER_SLASHINGS,
         MAX_VALIDATORS_PER_COMMITTEE,
         MAX_ATTESTER_SLASHINGS,


### PR DESCRIPTION
i was a bit too hasty when making the skeletons of the various subtransitions and copypasta'd some `mut` `BeaconBlock`s into the code.

there is no reason to mutate a beacon block in the state transition so let's drop the `mut` capability
