### PR TITLE
feat: add fn body for 'process_participation_record_updates'

### DIFF
--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -288,7 +288,7 @@ pub fn process_randao_mixes_reset<
     context: &Context,
 ) -> Result<(), Error> {
     let current_epoch = get_current_epoch(state, context);
-    let next_epoch = get_current_epoch(state, context) + 1;
+    let next_epoch = current_epoch + 1;
 
     state.randao_mixes[next_epoch as usize % context.epochs_per_historical_vector] =
         get_randao_mix(state, current_epoch).clone();

--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -5,6 +5,7 @@ use crate::phase0::state_transition::{
 };
 use crate::primitives::Epoch;
 use ssz_rs::prelude::*;
+use std::mem;
 
 pub fn get_matching_source_attestations<
     'a,
@@ -340,11 +341,10 @@ pub fn process_participation_record_updates<
         MAX_VALIDATORS_PER_COMMITTEE,
         PENDING_ATTESTATIONS_BOUND,
     >,
-    _context: &Context,
 ) -> Result<(), Error> {
-    state.previous_epoch_attestations = state.current_epoch_attestations.clone();
-    state.current_epoch_attestations.clear();
-    
+    let current_attestations = mem::take(&mut state.current_epoch_attestations);
+    state.previous_epoch_attestations = current_attestations;
+
     Ok(())
 }
 
@@ -379,6 +379,6 @@ pub fn process_epoch<
     process_slashings_reset(state, context)?;
     process_randao_mixes_reset(state, context)?;
     process_historical_roots_update(state, context)?;
-    process_participation_record_updates(state, context)?;
+    process_participation_record_updates(state)?;
     Ok(())
 }

--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -1,7 +1,7 @@
 use crate::phase0::beacon_state::BeaconState;
 use crate::phase0::operations::PendingAttestation;
 use crate::phase0::state_transition::{
-    get_block_root, get_current_epoch, get_previous_epoch, Context, Error,
+    get_block_root, get_current_epoch, get_previous_epoch, get_randao_mix, Context, Error,
 };
 use crate::primitives::Epoch;
 use ssz_rs::prelude::*;
@@ -275,7 +275,7 @@ pub fn process_randao_mixes_reset<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const PENDING_ATTESTATIONS_BOUND: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -285,8 +285,13 @@ pub fn process_randao_mixes_reset<
         MAX_VALIDATORS_PER_COMMITTEE,
         PENDING_ATTESTATIONS_BOUND,
     >,
-    _context: &Context,
+    context: &Context,
 ) -> Result<(), Error> {
+    let current_epoch = get_current_epoch(state, context);
+    let next_epoch = get_current_epoch(state, context) + 1;
+
+    state.randao_mixes[next_epoch as usize % context.epochs_per_historical_vector] =
+        get_randao_mix(state, current_epoch).clone();
     Ok(())
 }
 

--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -330,7 +330,7 @@ pub fn process_participation_record_updates<
     const MAX_VALIDATORS_PER_COMMITTEE: usize,
     const PENDING_ATTESTATIONS_BOUND: usize,
 >(
-    _state: &mut BeaconState<
+    state: &mut BeaconState<
         SLOTS_PER_HISTORICAL_ROOT,
         HISTORICAL_ROOTS_LIMIT,
         ETH1_DATA_VOTES_BOUND,
@@ -342,6 +342,9 @@ pub fn process_participation_record_updates<
     >,
     _context: &Context,
 ) -> Result<(), Error> {
+    state.previous_epoch_attestations = state.current_epoch_attestations.clone();
+    state.current_epoch_attestations.clear();
+    
     Ok(())
 }
 


### PR DESCRIPTION
@ralexstokes before I merge this -- since you were just creating skeletons, should I remove `_context` from the fn parameters if it's unused? Or, are you trying to keep everything sorta consistent with `state` and `context` always being passed?