### PR TITLE
feat: add fn body to `process_registry_updates`

### DIFF
--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -187,7 +187,6 @@ pub fn process_registry_updates<
             }
         })
         .collect::<Vec<ValidatorIndex>>();
-        
     // Order by the sequence of activation_eligibility_epoch setting and then index
     activation_queue.sort_by(|&i, &j| {
         let a = &state.validators[i];

--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -187,6 +187,7 @@ pub fn process_registry_updates<
             }
         })
         .collect::<Vec<ValidatorIndex>>();
+        
     // Order by the sequence of activation_eligibility_epoch setting and then index
     activation_queue.sort_by(|&i, &j| {
         let a = &state.validators[i];

--- a/src/phase0/state_transition/mod.rs
+++ b/src/phase0/state_transition/mod.rs
@@ -715,13 +715,13 @@ pub fn get_validator_churn_limit<
         PENDING_ATTESTATIONS_BOUND,
     >,
     context: &Context,
-) -> u64 {
+) -> usize {
     let active_validator_indices =
         get_active_validator_indices(state, get_current_epoch(state, context));
     u64::max(
         context.min_per_epoch_churn_limit,
         active_validator_indices.len() as u64 / context.churn_limit_quotient,
-    )
+    ) as usize
 }
 
 pub fn get_seed<


### PR DESCRIPTION
This PR is a WIP as I'm having some issues with Rust and am looking for feedback.

I'm trying to implement [`process_registry_updates`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#registry-updates), which has 3 primary steps:

- [x] Process activation eligibility and ejections
- [x] Queue validators eligible for activation and not yet dequeued for activation
- [x] Dequeued validators for activation up to churn limit

I think I have the first step completed (obviously open to feedback), but I've had issues on the next step while trying to recreate python's lambda & sorting. This is what I've tried to do:
1. Get validators from state
2. Create an iterator and enumerate over the values to get a tuple of `(ValidatorIndex, &Validator)`
3. Sort the values in place (I think this is what `sort_by` does) with priority of `activation_eligibility_epoch`, then validator's `index` (where the variables in the closure could be removed but are created for clarity)
4. Map the values so that the final result is just a vector of `ValidatorIndex`s

I'm running into issues somewhere prior to step 4 because in the code's current state (stops after step 3), the type on `activation_queue` is simply `()`...instead of a vector of `(ValidatorIndex, &Validator)`. I'm also not sure if using `sort_by` is the only option here but wanted to avoid using other crates that accomplish this.