### PR TITLE
feat: add `process_rewards_and_penalties` impl & helper fns

### DIFF
--- a/src/phase0/mod.rs
+++ b/src/phase0/mod.rs
@@ -27,6 +27,6 @@ pub mod mainnet {
 
 pub mod minimal {}
 
-pub const BASE_REWARDS_PER_EPOCH: usize = 4;
+pub const BASE_REWARDS_PER_EPOCH: u64 = 4;
 pub const DEPOSIT_CONTRACT_TREE_DEPTH: usize = 2usize.pow(5);
 pub const JUSTIFICATION_BITS_LENGTH: usize = 4;

--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -740,8 +740,8 @@ pub fn get_source_deltas<
     // Return attester micro-rewards/penalties for source-vote for each validator.
     let previous_epoch = get_previous_epoch(state, context);
     let matching_source_attestations =
-        get_matching_source_attestations(state, previous_epoch, context)?.iter();
-    get_attestation_component_deltas(state, matching_source_attestations, context)
+        get_matching_source_attestations(state, previous_epoch, context)?;
+    get_attestation_component_deltas(state, matching_source_attestations.iter(), context)
 }
 
 pub fn get_target_deltas<
@@ -823,7 +823,7 @@ pub fn get_inclusion_delay_deltas<
         PENDING_ATTESTATIONS_BOUND,
     >,
     context: &Context,
-) -> Result<(Vec<Gwei>, Vec<Gwei>), Error> {
+) -> Result<Vec<Gwei>, Error> {
     // Return proposer and inclusion delay micro-rewards/penalties for each validator.
     let previous_epoch = get_previous_epoch(state, context);
     let validator_count = state.validators.len();
@@ -847,8 +847,8 @@ pub fn get_inclusion_delay_deltas<
         rewards[i] += max_attester_reward / attestation.inclusion_delay;
     }
     // No penalties associated with inclusion delay
-    let penalties = vec![0; validator_count];
-    Ok((rewards, penalties))
+    // Note: a slight deviation from the spec -- `penalties` is not provided in the return since it's unused
+    Ok(rewards)
 }
 
 pub fn get_inactivity_penalty_deltas<
@@ -872,7 +872,7 @@ pub fn get_inactivity_penalty_deltas<
         PENDING_ATTESTATIONS_BOUND,
     >,
     context: &Context,
-) -> Result<(Vec<Gwei>, Vec<Gwei>), Error> {
+) -> Result<Vec<Gwei>, Error> {
     // Return inactivity reward/penalty deltas for each validator.
     let previous_epoch = get_previous_epoch(state, context);
     let validator_count = state.validators.len();
@@ -895,8 +895,8 @@ pub fn get_inactivity_penalty_deltas<
         }
     }
     // No rewards associated with inactivity penalties
-    let rewards = vec![0; validator_count];
-    Ok((rewards, penalties))
+    // Note: a slight deviation from the spec -- `rewards` is not provided in the return since it's unused
+    Ok(penalties)
 }
 
 pub fn get_attestation_deltas<
@@ -925,8 +925,8 @@ pub fn get_attestation_deltas<
     let (source_rewards, source_penalties) = get_source_deltas(state, context)?;
     let (target_rewards, target_penalties) = get_target_deltas(state, context)?;
     let (head_rewards, head_penalties) = get_head_deltas(state, context)?;
-    let (inclusion_delay_rewards, _) = get_inclusion_delay_deltas(state, context)?;
-    let (_, inactivity_penalties) = get_inactivity_penalty_deltas(state, context)?;
+    let inclusion_delay_rewards = get_inclusion_delay_deltas(state, context)?;
+    let inactivity_penalties = get_inactivity_penalty_deltas(state, context)?;
 
     let validator_count = state.validators.len();
     let mut rewards = vec![0; validator_count];

--- a/src/phase0/state_transition/epoch_processing.rs
+++ b/src/phase0/state_transition/epoch_processing.rs
@@ -150,20 +150,13 @@ pub fn get_unslashed_attesting_indices<
 ) -> Result<HashSet<ValidatorIndex>, Error> {
     let mut output = HashSet::new();
     for a in attestations {
-        output = output
-            .union(&get_attesting_indices(
-                state,
-                &a.data,
-                &a.aggregation_bits,
-                context,
-            )?)
-            .cloned()
-            .collect::<HashSet<_>>();
+        for index in get_attesting_indices(state, &a.data, &a.aggregation_bits, context)? {
+            if !state.validators[index].slashed {
+                output.insert(index);
+            }
+        }
     }
-    Ok(output
-        .into_iter()
-        .filter(|&i| !state.validators[i].slashed)
-        .collect())
+    Ok(output)
 }
 
 pub fn process_justification_and_finalization<

--- a/src/phase0/state_transition/mod.rs
+++ b/src/phase0/state_transition/mod.rs
@@ -975,7 +975,7 @@ pub fn get_total_balance<
         MAX_VALIDATORS_PER_COMMITTEE,
         PENDING_ATTESTATIONS_BOUND,
     >,
-    indices: HashSet<ValidatorIndex>,
+    indices: &HashSet<ValidatorIndex>,
     context: &Context,
 ) -> Result<Gwei, Error> {
     let total_balance = indices
@@ -1010,7 +1010,7 @@ pub fn get_total_active_balance<
     context: &Context,
 ) -> Result<Gwei, Error> {
     let indices = get_active_validator_indices(state, get_current_epoch(state, context));
-    get_total_balance(state, HashSet::from_iter(indices), context)
+    get_total_balance(state, &HashSet::from_iter(indices), context)
 }
 
 pub fn get_indexed_attestation<

--- a/src/phase0/state_transition/mod.rs
+++ b/src/phase0/state_transition/mod.rs
@@ -46,6 +46,8 @@ pub enum Error {
     },
     #[error("overflow")]
     Overflow,
+    #[error("invalid attestation")]
+    InvalidAttestation,
     #[error("{0}")]
     InvalidBlock(InvalidBlock),
     #[error("an invalid transition to a past slot {requested} from slot {current}")]


### PR DESCRIPTION
Add skeletons for all remaining functions yet to be implemented but required by `process_rewards_and_penalties` and its related helpers/subfunctions (where duplicate fns are listed here to define their missing dependencies):
- `process_rewards_and_penalties`
    - `get_attestation_deltas`
        - `get_attestation_component_deltas`
            - `get_unslashed_attesting_indices`
            - `get_eligible_validator_indices`
            - `is_in_inactivity_leak`
                - `get_finality_delay`
            - `get_base_reward`
        - `get_source_deltas`
        - `get_target_deltas`
        - `get_head_deltas`
            - `get_matching_head_attestations`
        - `get_inclusion_delay_deltas`
            - `get_unslashed_attesting_indices`
            - `get_proposer_reward`
            - `get_base_reward`
            - `get_proposer_reward`
        - `get_inactivity_penalty_deltas`
            - `is_in_inactivity_leak`
                - `get_finality_delay`
            - `get_unslashed_attesting_indices`
            - `get_eligible_validator_indices`
            - `get_base_reward`
            - `get_proposer_reward`
            - `get_finality_delay`