### PR TITLE
fix: remove `InvalidAttestation` from `Error`

### DIFF
--- a/src/phase0/state_transition/mod.rs
+++ b/src/phase0/state_transition/mod.rs
@@ -46,8 +46,6 @@ pub enum Error {
     },
     #[error("overflow")]
     Overflow,
-    #[error("invalid attestation")]
-    InvalidAttestation,
     #[error("{0}")]
     InvalidBlock(InvalidBlock),
     #[error("an invalid transition to a past slot {requested} from slot {current}")]


### PR DESCRIPTION
As part of commit https://github.com/ralexstokes/ethereum_consensus/commit/850c8a01c209a66e63e69e5c2098e65fc0c56a3a, the `InvalidAttestation` and corresponding `error` macro were accidentally included. However, they were deemed unneeded and should not be part of this commit.