### PR TITLE
Fix `index` check in `compute_shuffled_index`

### DIFF
--- a/src/phase0/state_transition/mod.rs
+++ b/src/phase0/state_transition/mod.rs
@@ -498,7 +498,7 @@ pub fn compute_shuffled_index(
     seed: &Bytes32,
     context: &Context,
 ) -> Option<usize> {
-    if index < index_count {
+    if index >= index_count {
         return None;
     }
 


### PR DESCRIPTION
According to spec, `index` should be less than `index_count`. But `None` is returned if so.
```python3
def compute_shuffled_index(index: uint64, index_count: uint64, seed: Bytes32) -> uint64:
    assert index < index_count
    # ...
```