### PR TITLE
Fix `get_seed` fn

### DIFF
--- a/src/phase0/state_transition/mod.rs
+++ b/src/phase0/state_transition/mod.rs
@@ -847,9 +847,9 @@ pub fn get_seed<
     domain_type: DomainType,
     context: &Context,
 ) -> Bytes32 {
-    let epoch =
+    let mix_epoch =
         epoch + (context.epochs_per_historical_vector as u64 - context.min_seed_lookahead) - 1;
-    let mix = get_randao_mix(state, epoch);
+    let mix = get_randao_mix(state, mix_epoch);
     let mut input = [0u8; 44];
     input[..4].copy_from_slice(&domain_type.as_bytes());
     input[4..12].copy_from_slice(&epoch.to_le_bytes());


### PR DESCRIPTION
Closes https://github.com/ralexstokes/ethereum_consensus/issues/67

The `epoch` variable was overridden with the epoch for getting randao mix.

According to the spec, this shouldn't happen:
```python3
def get_seed(state: BeaconState, epoch: Epoch, domain_type: DomainType) -> Bytes32:
    """
    Return the seed at ``epoch``.
    """
    mix = get_randao_mix(state, Epoch(epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD - 1))  # Avoid underflow
    return hash(domain_type + uint_to_bytes(epoch) + mix)
```